### PR TITLE
chore: remove remote addr from log

### DIFF
--- a/quic/connection.nim
+++ b/quic/connection.nim
@@ -52,7 +52,7 @@ proc startSending(connection: Connection, remote: TransportAddress) =
     try:
       trace "Getting datagram"
       let datagram = await connection.quic.outgoing.get()
-      trace "Sending datagraom", remote
+      trace "Sending datagraom"
       await connection.udp.sendTo(remote, datagram.data)
       trace "Sent datagraom"
     except TransportError as e:


### PR DESCRIPTION
Using this in nim-libp2p creates the error:

`/Users/runner/work/nim-libp2p/nim-libp2p/nimbledeps/pkgs/json_serialization-#85b7ea093cb85ee4f433a617b97571bd709d30df/json_serialization/writer.nim(249, 12) Error: fatal error: Failed to convert to JSON an unsupported type: Port`

Also

```nim
import json_serialization/writer
import chronos

toJSON(initTAddress("127.0.0.1:1234"))
```

fails with

/nim-libp2p/nimbledeps/pkgs/json_serialization-#8a4ed98bbd0a9479df15af2fa31da38a586ea6d5/json_serialization/writer.nim(203, 8) template/generic instantiation of enumInstanceSerializedFields from here
/nim-libp2p/nimbledeps/pkgs/serialization-#298a9554a885b2df59737bb3461aac8d0d339724/serialization/object_serialization.nim(48, 40) Error: type mismatch: got <uint16>
but expected one of:
iterator fieldPairs[S: tuple | object; T: tuple | object](x: S; y: T): tuple[
    key: string, a, b: RootObj]
  first type mismatch at position: 1
  required type for x: S: tuple or object
  but expression 'value' is of type: uint16
iterator fieldPairs[T: tuple | object](x: T): tuple[key: string, val: RootObj]
  first type mismatch at position: 1
  required type for x: T: tuple or object
  but expression 'value' is of type: uint16

expression: fieldPairs(value) 
Those are the last commits for nim-json-serialization and nim-serialization