### PR TITLE
fix: close should clean stream userdata

### DIFF
--- a/quic/transport/ngtcp2/native/streams.nim
+++ b/quic/transport/ngtcp2/native/streams.nim
@@ -50,7 +50,8 @@ proc onReceiveStreamData(
   var bytes = newSeqUninitialized[byte](datalen)
   copyMem(bytes.toUnsafePtr, data, datalen)
   let isFin = (flags and NGTCP2_STREAM_DATA_FLAG_FIN) != 0
-  state.receive(uint64(offset), bytes, isFin)
+  if state != nil:
+    state.receive(uint64(offset), bytes, isFin)
 
 proc onStreamReset(
     connection: ptr ngtcp2_conn,


### PR DESCRIPTION
I noticed that since we currently do not handle half open states, it was possible for a dangling pointer to be left when closing an stream, since before the code did not actively call setUserData with a nil state. In this PR i assume that calling stream.close() is similar to Go in which it closes both the Read and the Write. hence as soon as Close state is entered, it will clear the stream userdata from ngtcp2.

This might need some changes if we decide in the future to handle half closed states (not sure tho)