### PR TITLE
fix: closing stream on stream reset

### DIFF
--- a/quic/transport/ngtcp2/native/streams.nim
+++ b/quic/transport/ngtcp2/native/streams.nim
@@ -62,10 +62,9 @@ proc onStreamReset(
     stream_user_data: pointer,
 ): cint {.cdecl.} =
   trace "onStreamReset"
-  let stream = cast[Stream](stream_user_data)
-  if stream != nil:
-    stream.onClose()
-  return 0
+  let state = cast[StreamState](stream_user_data)
+  if state != nil:
+    state.reset()
 
 proc onStreamStopSending(
     conn: ptr ngtcp2_conn,

--- a/quic/transport/ngtcp2/stream/closedstate.nim
+++ b/quic/transport/ngtcp2/stream/closedstate.nim
@@ -48,7 +48,7 @@ method isClosed*(state: ClosedStream): bool =
 method receive*(state: ClosedStream, offset: uint64, bytes: seq[byte], isFin: bool) =
   discard
 
-method reset*(state: ClosedStream) {.async.} =
+method reset*(state: ClosedStream) =
   discard
 
 method expire*(state: ClosedStream) {.raises: [].} =

--- a/quic/transport/stream.nim
+++ b/quic/transport/stream.nim
@@ -30,7 +30,7 @@ method write*(state: StreamState, bytes: seq[byte]) {.base, async.} =
 method close*(state: StreamState) {.base, async.} =
   doAssert false, "override this method"
 
-method reset*(state: StreamState) {.base, async.} =
+method reset*(state: StreamState) {.base.} =
   doAssert false, "override this method"
 
 method onClose*(state: StreamState) {.base.} =
@@ -71,8 +71,8 @@ proc write*(stream: Stream, bytes: seq[byte]) {.async.} =
 proc close*(stream: Stream) {.async.} =
   await stream.state.close()
 
-proc reset*(stream: Stream) {.async.} =
-  await stream.state.reset()
+proc reset*(stream: Stream) =
+  stream.state.reset()
 
 proc onClose*(stream: Stream) =
   stream.state.onClose()

--- a/tests/quic/testStreams.nim
+++ b/tests/quic/testStreams.nim
@@ -49,7 +49,7 @@ suite "streams":
 
   asyncTest "raises when reading from or writing to reset stream":
     let stream = await client.openStream()
-    await stream.reset()
+    stream.reset()
     expect QuicError:
       discard await stream.read()
 


### PR DESCRIPTION
Fixes the error seen here: https://github.com/vacp2p/nim-libp2p/actions/runs/15193656027/job/42732413624?pr=1392 that happens frequently with zig, due to them sending a reset when shutting down a stream

```
   dialer-1    | Traceback (most recent call last)
  dialer-1    | /app/nim-libp2p/tests/transport-interop/main.nim(110) main
  dialer-1    | /app/nim-libp2p/nimbledeps/pkgs/chronos-#b55e2816eb45f698ddaca8d8473e401502562db2/chronos/internal/asyncfutures.nim(638) waitFor
  dialer-1    | /app/nim-libp2p/nimbledeps/pkgs/chronos-#b55e2816eb45f698ddaca8d8473e401502562db2/chronos/internal/asyncfutures.nim(624) pollFor
  dialer-1    | /app/nim-libp2p/nimbledeps/pkgs/chronos-#b55e2816eb45f698ddaca8d8473e401502562db2/chronos/internal/asyncengine.nim(150) poll
  dialer-1    | /app/nim-libp2p/nimbledeps/pkgs/chronos-#b55e2816eb45f698ddaca8d8473e401502562db2/chronos/transports/datagram.nim(463) readDatagramLoop
  dialer-1    | /app/nim-libp2p/nimbledeps/pkgs/chronos-#b55e2816eb45f698ddaca8d8473e401502562db2/chronos/transports/datagram.nim(723) wrap
  dialer-1    | /app/nim-libp2p/nimbledeps/pkgs/quic-#892feade77cfd84692026f8123c8825d8f2273c8/quic/api.nim(112) onReceive
  dialer-1    | /app/nim-libp2p/nimbledeps/pkgs/quic-#892feade77cfd84692026f8123c8825d8f2273c8/quic/connection.nim(195) receive
  dialer-1    | /app/nim-libp2p/nimbledeps/pkgs/quic-#892feade77cfd84692026f8123c8825d8f2273c8/quic/transport/quicconnection.nim(85) receive
  dialer-1    | /app/nim-libp2p/nimbledeps/pkgs/quic-#892feade77cfd84692026f8123c8825d8f2273c8/quic/transport/quicconnection.nim(42) receive
  dialer-1    | /app/nim-libp2p/nimbledeps/pkgs/quic-#892feade77cfd84692026f8123c8825d8f2273c8/quic/transport/ngtcp2/connection/openstate.nim(109) receive
  dialer-1    | /app/nim-libp2p/nimbledeps/pkgs/quic-#892feade77cfd84692026f8123c8825d8f2273c8/quic/transport/ngtcp2/native/connection.nim(201) receive
  dialer-1    | /app/nim-libp2p/nimbledeps/pkgs/quic-#892feade77cfd84692026f8123c8825d8f2273c8/quic/transport/ngtcp2/native/connection.nim(196) receive
  dialer-1    | /app/nim-libp2p/nimbledeps/pkgs/quic-#892feade77cfd84692026f8123c8825d8f2273c8/quic/transport/ngtcp2/native/connection.nim(183) tryReceive
  dialer-1    | /app/nim-libp2p/nimbledeps/pkgs/quic-#892feade77cfd84692026f8123c8825d8f2273c8/quic/transport/ngtcp2/native/streams.nim(67) onStreamReset
  dialer-1    | /app/nim-libp2p/nimbledeps/pkgs/quic-#892feade77cfd84692026f8123c8825d8f2273c8/quic/transport/stream.nim(78) onClose
  dialer-1    | /app/nim-libp2p/nimbledeps/pkgs/quic-#892feade77cfd84692026f8123c8825d8f2273c8/quic/transport/stream.nim(36) onClose
  dialer-1    | SIGSEGV: Illegal storage access. (Attempt to read from nil?)
```