### PR TITLE
refactor: make certificates part of the connection

### DIFF
--- a/quic/transport/ngtcp2/connection/closedstate.nim
+++ b/quic/transport/ngtcp2/connection/closedstate.nim
@@ -12,8 +12,8 @@ type
   ClosedConnection* = ref object of ConnectionState
   ClosedConnectionError* = object of ConnectionError
 
-proc newClosedConnection*(): ClosedConnection =
-  ClosedConnection()
+proc newClosedConnection*(certificates: seq[seq[byte]]): ClosedConnection =
+  ClosedConnection(derCertificates: certificates)
 
 method ids(state: ClosedConnection): seq[ConnectionId] =
   @[]
@@ -36,6 +36,3 @@ method drop(state: ClosedConnection) {.async.} =
   trace "Dropping ClosedConnection state"
   discard
   trace "Dropped ClosedConnection state"
-
-method certificates(state: ClosedConnection): seq[seq[byte]] {.raises: [].} =
-  discard

--- a/quic/transport/ngtcp2/connection/closingstate.nim
+++ b/quic/transport/ngtcp2/connection/closingstate.nim
@@ -7,10 +7,13 @@ type ClosingConnection* = ref object of DrainingConnection
   finalDatagram: Datagram
 
 proc newClosingConnection*(
-    finalDatagram: Datagram, ids: seq[ConnectionId], duration: Duration
+    finalDatagram: Datagram,
+    ids: seq[ConnectionId],
+    duration: Duration,
+    certificates: seq[seq[byte]],
 ): ClosingConnection =
   let state = ClosingConnection(finalDatagram: finalDatagram)
-  state.init(ids, duration)
+  state.init(ids, duration, certificates)
   state
 
 proc sendFinalDatagram(state: ClosingConnection) =

--- a/quic/transport/quicconnection.nim
+++ b/quic/transport/quicconnection.nim
@@ -20,6 +20,7 @@ type
 
   ConnectionState* = ref object of RootObj
     entered: bool
+    derCertificates*: seq[seq[byte]]
 
   IdCallback* = proc(id: ConnectionId) {.gcsafe, raises: [].}
   ConnectionError* = object of QuicError
@@ -51,8 +52,8 @@ method drop*(state: ConnectionState): Future[void] {.gcsafe.} =
 method close*(state: ConnectionState): Future[void] {.gcsafe.} =
   doAssert false # override this method
 
-method certificates*(state: ConnectionState): seq[seq[byte]] {.raises: [].} =
-  doAssert false # override this method
+proc certificates*(state: ConnectionState): seq[seq[byte]] {.raises: [].} =
+  state.derCertificates
 
 {.pop.}
 


### PR DESCRIPTION
This will ensure you can access the certificates used for a connection, regardless of the connection state