### PR TITLE
fix: race condition when reading and receiving eof

### DIFF
--- a/quic/transport/framesorter.nim
+++ b/quic/transport/framesorter.nim
@@ -23,6 +23,10 @@ proc isEOF*(fs: FrameSorter): bool =
 
   return fs.emitPos >= fs.totalBytes.get()
 
+proc completeEofFut(fs: FrameSorter) =
+  if fs.isEOF() and not fs.eofFut.finished:
+    fs.eofFut.complete()
+
 proc putToQueue(fs: FrameSorter, data: seq[byte]) {.raises: [QuicError].} =
   if data.len > 0:
     try:
@@ -30,8 +34,7 @@ proc putToQueue(fs: FrameSorter, data: seq[byte]) {.raises: [QuicError].} =
     except AsyncQueueFullError:
       raise newException(QuicError, "Incoming queue is full")
 
-  if fs.isEOF() and not fs.eofFut.finished:
-    fs.eofFut.complete()
+  fs.completeEofFut()
 
 proc emitBufferedData(fs: var FrameSorter) {.raises: [QuicError].} =
   var emitData: seq[byte]
@@ -50,8 +53,10 @@ proc insert*(
 ) {.raises: [QuicError].} =
   if isFin and fs.totalBytes.isNone:
     fs.totalBytes = Opt.some(offset.int64 + max(data.len - 1, 0))
-    if fs.isEOF() and not fs.eofFut.finished:
-      fs.eofFut.complete()
+    defer:
+      # complete EOF fut in defer so that it happens after 
+      # data is written to incoming queue (if any)
+      fs.completeEofFut()
 
   # if offset matches emit position, framesorter can emit entire input in batch
   if offset.int == fs.emitPos and data.len > 0:

--- a/quic/transport/framesorter.nim
+++ b/quic/transport/framesorter.nim
@@ -22,11 +22,12 @@ proc isEOF*(fs: FrameSorter): bool =
 
   return fs.emitPos >= fs.totalBytes.get()
 
-proc sendEof(fs: var FrameSorter) =
+proc sendEof(fs: var FrameSorter) {.raises: [QuicError].} =
   if fs.isEOF() and not fs.sentEof:
-    fs.sentEof = true
+    # empty sequence is sent to unblock reading from incoming queue
     try:
       fs.incoming.putNoWait(@[])
+      fs.sentEof = true
     except AsyncQueueFullError:
       raise newException(QuicError, "Incoming queue is full")
 

--- a/quic/transport/framesorter.nim
+++ b/quic/transport/framesorter.nim
@@ -8,12 +8,20 @@ type FrameSorter* = object
   incoming*: AsyncQueue[seq[byte]]
   totalBytes*: Opt[int64]
     # contains total bytes for frame; and is known once a FIN is received
+  eofFut*: Future[void]
 
 proc initFrameSorter*(incoming: AsyncQueue[seq[byte]]): FrameSorter =
   result.incoming = incoming
   result.buffer = initTable[int64, byte]()
   result.emitPos = 0
   result.totalBytes = Opt.none(int64)
+  result.eofFut = newFuture[void]()
+
+proc isEOF*(fs: FrameSorter): bool =
+  if fs.totalBytes.isNone:
+    return false
+
+  return fs.emitPos >= fs.totalBytes.get()
 
 proc putToQueue(fs: FrameSorter, data: seq[byte]) {.raises: [QuicError].} =
   if data.len > 0:
@@ -21,6 +29,9 @@ proc putToQueue(fs: FrameSorter, data: seq[byte]) {.raises: [QuicError].} =
       fs.incoming.putNoWait(data)
     except AsyncQueueFullError:
       raise newException(QuicError, "Incoming queue is full")
+  
+  if fs.isEOF() and not fs.eofFut.finished:
+    fs.eofFut.complete()
 
 proc emitBufferedData(fs: var FrameSorter) {.raises: [QuicError].} =
   var emitData: seq[byte]
@@ -39,6 +50,8 @@ proc insert*(
 ) {.raises: [QuicError].} =
   if isFin and fs.totalBytes.isNone:
     fs.totalBytes = Opt.some(offset.int64 + max(data.len - 1, 0))
+    if fs.isEOF() and not fs.eofFut.finished:
+      fs.eofFut.complete()
 
   # if offset matches emit position, framesorter can emit entire input in batch
   if offset.int == fs.emitPos and data.len > 0:
@@ -69,12 +82,6 @@ proc insert*(
 
   # Try to emit contiguous data
   fs.emitBufferedData()
-
-proc isEOF*(fs: FrameSorter): bool =
-  if fs.totalBytes.isNone:
-    return false
-
-  return fs.emitPos >= fs.totalBytes.get()
 
 proc reset*(fs: var FrameSorter) =
   fs.totalBytes = Opt.none(int64)

--- a/quic/transport/framesorter.nim
+++ b/quic/transport/framesorter.nim
@@ -8,14 +8,13 @@ type FrameSorter* = object
   incoming*: AsyncQueue[seq[byte]]
   totalBytes*: Opt[int64]
     # contains total bytes for frame; and is known once a FIN is received
-  eofFut*: Future[void]
+  sentEof: bool
 
 proc initFrameSorter*(incoming: AsyncQueue[seq[byte]]): FrameSorter =
   result.incoming = incoming
   result.buffer = initTable[int64, byte]()
   result.emitPos = 0
   result.totalBytes = Opt.none(int64)
-  result.eofFut = newFuture[void]()
 
 proc isEOF*(fs: FrameSorter): bool =
   if fs.totalBytes.isNone:
@@ -23,18 +22,22 @@ proc isEOF*(fs: FrameSorter): bool =
 
   return fs.emitPos >= fs.totalBytes.get()
 
-proc completeEofFut(fs: FrameSorter) =
-  if fs.isEOF() and not fs.eofFut.finished:
-    fs.eofFut.complete()
+proc sendEof(fs: var FrameSorter) =
+  if fs.isEOF() and not fs.sentEof:
+    fs.sentEof = true
+    try:
+      fs.incoming.putNoWait(@[])
+    except AsyncQueueFullError:
+      raise newException(QuicError, "Incoming queue is full")
 
-proc putToQueue(fs: FrameSorter, data: seq[byte]) {.raises: [QuicError].} =
+proc putToQueue(fs: var FrameSorter, data: seq[byte]) {.raises: [QuicError].} =
   if data.len > 0:
     try:
       fs.incoming.putNoWait(data)
     except AsyncQueueFullError:
       raise newException(QuicError, "Incoming queue is full")
 
-  fs.completeEofFut()
+  fs.sendEof()
 
 proc emitBufferedData(fs: var FrameSorter) {.raises: [QuicError].} =
   var emitData: seq[byte]
@@ -54,9 +57,9 @@ proc insert*(
   if isFin and fs.totalBytes.isNone:
     fs.totalBytes = Opt.some(offset.int64 + max(data.len - 1, 0))
     defer:
-      # complete EOF fut in defer so that it happens after 
+      # send EOF in defer so that it happens after 
       # data is written to incoming queue (if any)
-      fs.completeEofFut()
+      fs.sendEof()
 
   # if offset matches emit position, framesorter can emit entire input in batch
   if offset.int == fs.emitPos and data.len > 0:
@@ -93,7 +96,7 @@ proc reset*(fs: var FrameSorter) =
   fs.buffer.clear()
   fs.incoming.clear()
   fs.emitPos = 0
-  fs.eofFut = newFuture[void]()
+  fs.sentEof = false
 
 proc isComplete*(fs: FrameSorter): bool =
   if fs.totalBytes.isNone:

--- a/quic/transport/framesorter.nim
+++ b/quic/transport/framesorter.nim
@@ -29,7 +29,7 @@ proc putToQueue(fs: FrameSorter, data: seq[byte]) {.raises: [QuicError].} =
       fs.incoming.putNoWait(data)
     except AsyncQueueFullError:
       raise newException(QuicError, "Incoming queue is full")
-  
+
   if fs.isEOF() and not fs.eofFut.finished:
     fs.eofFut.complete()
 

--- a/quic/transport/framesorter.nim
+++ b/quic/transport/framesorter.nim
@@ -88,6 +88,7 @@ proc reset*(fs: var FrameSorter) =
   fs.buffer.clear()
   fs.incoming.clear()
   fs.emitPos = 0
+  fs.eofFut = newFuture[void]()
 
 proc isComplete*(fs: FrameSorter): bool =
   if fs.totalBytes.isNone:

--- a/quic/transport/ngtcp2/stream/openstate.nim
+++ b/quic/transport/ngtcp2/stream/openstate.nim
@@ -63,7 +63,7 @@ method read*(state: OpenStream): Future[seq[byte]] {.async.} =
     # TODO: https://github.com/vacp2p/nim-quic/issues/92
     # this is temporall fix, delay is introduced to give
     # more priority to future reading from incoming queue
-    await sleepAsync(100.milliseconds)
+    await sleepAsync(50.milliseconds)
     await fut
 
   # Priority 3: Get data from incoming queue

--- a/quic/transport/ngtcp2/stream/openstate.nim
+++ b/quic/transport/ngtcp2/stream/openstate.nim
@@ -59,17 +59,10 @@ method read*(state: OpenStream): Future[seq[byte]] {.async.} =
     stream.switch(newClosedStream(state.incoming, state.frameSorter))
     return @[] # Return EOF for locally closed read
 
-  proc delayedFuture(fut: Future[void]): Future[void] {.async.} =
-    # TODO: https://github.com/vacp2p/nim-quic/issues/92
-    # this is temporall fix, delay is introduced to give
-    # more priority to future reading from incoming queue
-    await sleepAsync(100.milliseconds)
-    await fut
-
   # Priority 3: Get data from incoming queue
   var data: seq[byte]
   let getFut = state.incoming.get()
-  let fut = await race(getFut, delayedFuture(state.frameSorter.eofFut))
+  let fut = await race(getFut, state.frameSorter.eofFut)
   if fut == getFut:
     data = await getFut
 

--- a/quic/transport/ngtcp2/stream/openstate.nim
+++ b/quic/transport/ngtcp2/stream/openstate.nim
@@ -59,22 +59,19 @@ method read*(state: OpenStream): Future[seq[byte]] {.async.} =
     stream.switch(newClosedStream(state.incoming, state.frameSorter))
     return @[] # Return EOF for locally closed read
 
-  proc delayedFuture(): Future[string] {.async.} =
-    await sleepAsync(100)  # delay
-    await state.frameSorter.eofFut
-    return "Done after 100ms"
+  proc delayedFuture(fut: Future[void]): Future[void] {.async.} =
+    # TODO: https://github.com/vacp2p/nim-quic/issues/92
+    # this is temporall fix, delay is introduced to give
+    # more priority to future reading from incoming queue
+    await sleepAsync(200.milliseconds)
+    await fut
 
   # Priority 3: Get data from incoming queue
   var data: seq[byte]
-  if state.incoming.len == 0:
-    let getFut = state.incoming.get()
-    let fut = await race(getFut, delayedFuture())
-    if fut == getFut:
-      data = await getFut
-    elif state.incoming.len > 0:
-      data = await getFut
-  else:
-    data = await state.incoming.get()
+  let getFut = state.incoming.get()
+  let fut = await race(getFut, delayedFuture(state.frameSorter.eofFut))
+  if fut == getFut:
+    data = await getFut
 
   # If we got real data, return it with flow control update
   if data.len > 0:

--- a/quic/transport/ngtcp2/stream/openstate.nim
+++ b/quic/transport/ngtcp2/stream/openstate.nim
@@ -63,7 +63,7 @@ method read*(state: OpenStream): Future[seq[byte]] {.async.} =
     # TODO: https://github.com/vacp2p/nim-quic/issues/92
     # this is temporall fix, delay is introduced to give
     # more priority to future reading from incoming queue
-    await sleepAsync(200.milliseconds)
+    await sleepAsync(100.milliseconds)
     await fut
 
   # Priority 3: Get data from incoming queue

--- a/quic/transport/ngtcp2/stream/openstate.nim
+++ b/quic/transport/ngtcp2/stream/openstate.nim
@@ -60,7 +60,11 @@ method read*(state: OpenStream): Future[seq[byte]] {.async.} =
     return @[] # Return EOF for locally closed read
 
   # Priority 3: Get data from incoming queue
-  let data = await state.incoming.get()
+  var data: seq[byte]
+  let getFut = state.incoming.get()
+  let fut = await race(getFut, state.frameSorter.eofFut)
+  if fut == getFut:
+    data = await getFut
 
   # If we got real data, return it with flow control update
   if data.len > 0:

--- a/quic/transport/ngtcp2/stream/openstate.nim
+++ b/quic/transport/ngtcp2/stream/openstate.nim
@@ -59,10 +59,17 @@ method read*(state: OpenStream): Future[seq[byte]] {.async.} =
     stream.switch(newClosedStream(state.incoming, state.frameSorter))
     return @[] # Return EOF for locally closed read
 
+  proc delayedFuture(fut: Future[void]): Future[void] {.async.} =
+    # TODO: https://github.com/vacp2p/nim-quic/issues/92
+    # this is temporall fix, delay is introduced to give
+    # more priority to future reading from incoming queue
+    await sleepAsync(100.milliseconds)
+    await fut
+
   # Priority 3: Get data from incoming queue
   var data: seq[byte]
   let getFut = state.incoming.get()
-  let fut = await race(getFut, state.frameSorter.eofFut)
+  let fut = await race(getFut, delayedFuture(state.frameSorter.eofFut))
   if fut == getFut:
     data = await getFut
 

--- a/quic/transport/ngtcp2/stream/openstate.nim
+++ b/quic/transport/ngtcp2/stream/openstate.nim
@@ -61,10 +61,15 @@ method read*(state: OpenStream): Future[seq[byte]] {.async.} =
 
   # Priority 3: Get data from incoming queue
   var data: seq[byte]
-  let getFut = state.incoming.get()
-  let fut = await race(getFut, state.frameSorter.eofFut)
-  if fut == getFut:
-    data = await getFut
+  if state.incoming.len == 0:
+    let getFut = state.incoming.get()
+    let fut = await race(getFut, state.frameSorter.eofFut)
+    if fut == getFut:
+      data = await getFut
+    elif state.incoming.len > 0:
+      data = await getFut
+  else:
+    data = await state.incoming.get()
 
   # If we got real data, return it with flow control update
   if data.len > 0:

--- a/quic/transport/ngtcp2/stream/openstate.nim
+++ b/quic/transport/ngtcp2/stream/openstate.nim
@@ -63,7 +63,7 @@ method read*(state: OpenStream): Future[seq[byte]] {.async.} =
     # TODO: https://github.com/vacp2p/nim-quic/issues/92
     # this is temporall fix, delay is introduced to give
     # more priority to future reading from incoming queue
-    await sleepAsync(50.milliseconds)
+    await sleepAsync(100.milliseconds)
     await fut
 
   # Priority 3: Get data from incoming queue

--- a/quic/transport/ngtcp2/stream/openstate.nim
+++ b/quic/transport/ngtcp2/stream/openstate.nim
@@ -59,19 +59,8 @@ method read*(state: OpenStream): Future[seq[byte]] {.async.} =
     stream.switch(newClosedStream(state.incoming, state.frameSorter))
     return @[] # Return EOF for locally closed read
 
-  proc delayedFuture(fut: Future[void]): Future[void] {.async.} =
-    # TODO: https://github.com/vacp2p/nim-quic/issues/92
-    # this is temporall fix, delay is introduced to give
-    # more priority to future reading from incoming queue
-    await sleepAsync(100.milliseconds)
-    await fut
-
   # Priority 3: Get data from incoming queue
-  var data: seq[byte]
-  let getFut = state.incoming.get()
-  let fut = await race(getFut, delayedFuture(state.frameSorter.eofFut))
-  if fut == getFut:
-    data = await getFut
+  var data = await state.incoming.get()
 
   # If we got real data, return it with flow control update
   if data.len > 0:

--- a/quic/transport/ngtcp2/stream/openstate.nim
+++ b/quic/transport/ngtcp2/stream/openstate.nim
@@ -59,11 +59,16 @@ method read*(state: OpenStream): Future[seq[byte]] {.async.} =
     stream.switch(newClosedStream(state.incoming, state.frameSorter))
     return @[] # Return EOF for locally closed read
 
+  proc delayedFuture(): Future[string] {.async.} =
+    await sleepAsync(100)  # delay
+    await state.frameSorter.eofFut
+    return "Done after 100ms"
+
   # Priority 3: Get data from incoming queue
   var data: seq[byte]
   if state.incoming.len == 0:
     let getFut = state.incoming.get()
-    let fut = await race(getFut, state.frameSorter.eofFut)
+    let fut = await race(getFut, delayedFuture())
     if fut == getFut:
       data = await getFut
     elif state.incoming.len > 0:

--- a/quic/transport/ngtcp2/stream/openstate.nim
+++ b/quic/transport/ngtcp2/stream/openstate.nim
@@ -60,7 +60,7 @@ method read*(state: OpenStream): Future[seq[byte]] {.async.} =
     return @[] # Return EOF for locally closed read
 
   # Priority 3: Get data from incoming queue
-  var data = await state.incoming.get()
+  let data = await state.incoming.get()
 
   # If we got real data, return it with flow control update
   if data.len > 0:

--- a/tests/quic/testPerf.nim
+++ b/tests/quic/testPerf.nim
@@ -6,9 +6,10 @@ import pkg/quic/transport/stream
 import pkg/quic/transport/quicconnection
 import pkg/quic/transport/ngtcp2/native
 import pkg/quic/udp/datagram
+import pkg/stew/endians2
 import ../helpers/simulation
 
-suite "perf protocol like test":
+suite "perf protocol simulation":
   setup:
     var (client, server) = waitFor performHandshake()
 
@@ -16,7 +17,7 @@ suite "perf protocol like test":
     waitFor client.drop()
     waitFor server.drop()
 
-  asyncTest "perf protocol simulation":
+  asyncTest "test":
     # This test simulates the exact perf protocol flow:
     # 1. Client sends 8 bytes (download size)
     # 2. Client sends upload data (100KB)
@@ -36,8 +37,7 @@ suite "perf protocol like test":
       let serverStream = await server.incomingStream()
 
       # Step 1: Read download size (8 bytes) 
-      let sizeData = await serverStream.read()
-      # In real perf this would be parsed as uint64, but we skip that
+      let clientDownloadSize = await serverStream.read()
 
       # Step 2: Read upload data until EOF
       var totalBytesRead = 0
@@ -48,7 +48,7 @@ suite "perf protocol like test":
         totalBytesRead += chunk.len
 
       # Step 3: Send download data back
-      var remainingToSend = downloadSize
+      var remainingToSend = uint64.fromBytesBE(clientDownloadSize)
       while remainingToSend > 0:
         let toSend = min(remainingToSend, chunkSize)
         await serverStream.write(newSeq[byte](toSend))
@@ -59,16 +59,14 @@ suite "perf protocol like test":
     # Start server handler
     asyncSpawn serverHandler()
 
-    # Step 1: Send download size (8 bytes) - activate stream first
-    await clientStream.write(@[0'u8, 0'u8, 0'u8, 0'u8, 0'u8, 152'u8, 150'u8, 128'u8])
-      # 10MB in big endian
+    # Step 1: Send download size, activate stream first
+    await clientStream.write(toSeq(downloadSize.uint64.toBytesBE()))
 
     # Step 2: Send upload data in chunks
     var remainingToSend = uploadSize
     while remainingToSend > 0:
       let toSend = min(remainingToSend, chunkSize)
-      let dummyData = newSeq[byte](toSend)
-      await clientStream.write(dummyData)
+      await clientStream.write(newSeq[byte](toSend))
       remainingToSend -= toSend
 
     # Step 3: Close write side

--- a/tests/quic/testPerf.nim
+++ b/tests/quic/testPerf.nim
@@ -8,7 +8,7 @@ import pkg/quic/transport/ngtcp2/native
 import pkg/quic/udp/datagram
 import tests/helpers/simulation
 
-suite "perf protocol like test - half-close hang":
+suite "perf protocol like test":
   setup:
     var (client, server) = waitFor performHandshake()
 
@@ -16,7 +16,7 @@ suite "perf protocol like test - half-close hang":
     waitFor client.drop()
     waitFor server.drop()
 
-  asyncTest "perf protocol simulation hangs on read after closeWrite":
+  asyncTest "perf protocol simulation":
     # This test simulates the exact perf protocol flow:
     # 1. Client sends 8 bytes (download size)
     # 2. Client sends upload data (100KB)
@@ -47,7 +47,7 @@ suite "perf protocol like test - half-close hang":
       var totalBytesRead = 0
       while true:
         echo "SERVER: Waiting for next chunk..."
-        let chunk = await serverStream.read() # THIS WILL HANG after closeWrite!
+        let chunk = await serverStream.read()
         echo "SERVER: Read chunk: ", chunk.len, " bytes"
 
         if chunk.len == 0:

--- a/tests/quic/testPerf.nim
+++ b/tests/quic/testPerf.nim
@@ -1,0 +1,113 @@
+import std/sequtils
+import pkg/chronos
+import pkg/chronos/unittest2/asynctests
+import pkg/quic/errors
+import pkg/quic/transport/stream
+import pkg/quic/transport/quicconnection
+import pkg/quic/transport/ngtcp2/native
+import pkg/quic/udp/datagram
+import tests/helpers/simulation
+
+suite "perf protocol like test - half-close hang":
+  setup:
+    var (client, server) = waitFor performHandshake()
+
+  teardown:
+    waitFor client.drop()
+    waitFor server.drop()
+
+  asyncTest "perf protocol simulation hangs on read after closeWrite":
+    # This test simulates the exact perf protocol flow:
+    # 1. Client sends 8 bytes (download size)
+    # 2. Client sends upload data (100KB)
+    # 3. Client calls closeWrite() 
+    # 4. Server reads all data including the closeWrite signal (should get EOF)
+    # 5. Server sends download data back
+    
+    let simulation = simulateNetwork(client, server)
+    let clientStream = await client.openStream()
+    
+    const 
+      uploadSize = 100000  # 100KB like in perf test
+      downloadSize = 10000000  # 10MB like in perf test
+      chunkSize = 65536  # 64KB chunks like perf
+    
+    proc serverHandler() {.async.} =
+      let serverStream = await server.incomingStream()
+      echo "SERVER: Got incoming stream"
+      
+      # Step 1: Read download size (8 bytes) 
+      echo "SERVER: Reading download size (8 bytes)"
+      let sizeData = await serverStream.read()
+      echo "SERVER: Read download size: ", sizeData.len, " bytes"
+      # In real perf this would be parsed as uint64, but we skip that
+      
+      # Step 2: Read upload data until EOF
+      echo "SERVER: Starting to read upload data"
+      var totalBytesRead = 0
+      while true:
+        echo "SERVER: Waiting for next chunk..."
+        let chunk = await serverStream.read()  # THIS WILL HANG after closeWrite!
+        echo "SERVER: Read chunk: ", chunk.len, " bytes"
+        
+        if chunk.len == 0:
+          echo "SERVER: Got EOF, total read: ", totalBytesRead
+          break
+        
+        totalBytesRead += chunk.len
+        echo "SERVER: Total bytes read so far: ", totalBytesRead
+        
+        if totalBytesRead >= uploadSize:
+          echo "SERVER: Read all expected upload data"
+          break  # Exit the reading loop once we have all expected data
+      
+      echo "SERVER: Starting to send download data"
+      # Step 3: Send download data back
+      var remainingToSend = downloadSize
+      while remainingToSend > 0:
+        let toSend = min(remainingToSend, chunkSize)
+        let dummyData = newSeq[byte](toSend)
+        echo "about to send"
+        await serverStream.write(dummyData)
+        remainingToSend -= toSend
+        echo "SERVER: Sent ", toSend, " bytes, remaining: ", remainingToSend
+      
+      await serverStream.close()
+      echo "SERVER: Done"
+    
+    # Start server handler
+    asyncSpawn serverHandler()
+    
+    await clientStream.write(@[])
+
+    # Step 1: Send download size (8 bytes) - activate stream first
+    echo "CLIENT: Sending download size"
+    await clientStream.write(@[0'u8, 0'u8, 0'u8, 0'u8, 0'u8, 152'u8, 150'u8, 128'u8]) # 10MB in big endian
+    
+    # Step 2: Send upload data in chunks
+    echo "CLIENT: Starting upload of ", uploadSize, " bytes"
+    var remainingToSend = uploadSize
+    while remainingToSend > 0:
+      let toSend = min(remainingToSend, chunkSize)
+      let dummyData = newSeq[byte](toSend)
+      await clientStream.write(dummyData)
+      remainingToSend -= toSend
+      echo "CLIENT: Sent ", toSend, " bytes, remaining: ", remainingToSend
+    
+    # Step 3: Close write side (this is where the problem happens)
+    echo "CLIENT: Upload complete, closing write side"
+    await clientStream.closeWrite()
+    echo "CLIENT: Write side closed"
+    
+    # Step 4: Start reading download data
+    echo "CLIENT: Starting to read download data"
+    var totalDownloaded = 0
+    while totalDownloaded < downloadSize:
+      let chunk = await clientStream.read()
+      totalDownloaded += chunk.len
+      echo "CLIENT: Downloaded ", chunk.len, " bytes, total: ", totalDownloaded
+    
+    echo "CLIENT: Download complete"
+    await clientStream.close()
+    
+    await simulation.cancelAndWait()

--- a/tests/quic/testPerf.nim
+++ b/tests/quic/testPerf.nim
@@ -6,7 +6,7 @@ import pkg/quic/transport/stream
 import pkg/quic/transport/quicconnection
 import pkg/quic/transport/ngtcp2/native
 import pkg/quic/udp/datagram
-import tests/helpers/simulation
+import ../helpers/simulation
 
 suite "perf protocol like test":
   setup:

--- a/tests/quic/testPerf.nim
+++ b/tests/quic/testPerf.nim
@@ -71,7 +71,7 @@ suite "perf protocol like test":
       await clientStream.write(dummyData)
       remainingToSend -= toSend
 
-    # Step 3: Close write side (this is where the problem happens)
+    # Step 3: Close write side
     await clientStream.closeWrite()
 
     # Step 4: Start reading download data

--- a/tests/quic/testPerf.nim
+++ b/tests/quic/testPerf.nim
@@ -23,44 +23,44 @@ suite "perf protocol like test - half-close hang":
     # 3. Client calls closeWrite() 
     # 4. Server reads all data including the closeWrite signal (should get EOF)
     # 5. Server sends download data back
-    
+
     let simulation = simulateNetwork(client, server)
     let clientStream = await client.openStream()
-    
-    const 
-      uploadSize = 100000  # 100KB like in perf test
-      downloadSize = 10000000  # 10MB like in perf test
-      chunkSize = 65536  # 64KB chunks like perf
-    
+
+    const
+      uploadSize = 100000 # 100KB like in perf test
+      downloadSize = 10000000 # 10MB like in perf test
+      chunkSize = 65536 # 64KB chunks like perf
+
     proc serverHandler() {.async.} =
       let serverStream = await server.incomingStream()
       echo "SERVER: Got incoming stream"
-      
+
       # Step 1: Read download size (8 bytes) 
       echo "SERVER: Reading download size (8 bytes)"
       let sizeData = await serverStream.read()
       echo "SERVER: Read download size: ", sizeData.len, " bytes"
       # In real perf this would be parsed as uint64, but we skip that
-      
+
       # Step 2: Read upload data until EOF
       echo "SERVER: Starting to read upload data"
       var totalBytesRead = 0
       while true:
         echo "SERVER: Waiting for next chunk..."
-        let chunk = await serverStream.read()  # THIS WILL HANG after closeWrite!
+        let chunk = await serverStream.read() # THIS WILL HANG after closeWrite!
         echo "SERVER: Read chunk: ", chunk.len, " bytes"
-        
+
         if chunk.len == 0:
           echo "SERVER: Got EOF, total read: ", totalBytesRead
           break
-        
+
         totalBytesRead += chunk.len
         echo "SERVER: Total bytes read so far: ", totalBytesRead
-        
+
         if totalBytesRead >= uploadSize:
           echo "SERVER: Read all expected upload data"
-          break  # Exit the reading loop once we have all expected data
-      
+          break # Exit the reading loop once we have all expected data
+
       echo "SERVER: Starting to send download data"
       # Step 3: Send download data back
       var remainingToSend = downloadSize
@@ -71,19 +71,20 @@ suite "perf protocol like test - half-close hang":
         await serverStream.write(dummyData)
         remainingToSend -= toSend
         echo "SERVER: Sent ", toSend, " bytes, remaining: ", remainingToSend
-      
+
       await serverStream.close()
       echo "SERVER: Done"
-    
+
     # Start server handler
     asyncSpawn serverHandler()
-    
+
     await clientStream.write(@[])
 
     # Step 1: Send download size (8 bytes) - activate stream first
     echo "CLIENT: Sending download size"
-    await clientStream.write(@[0'u8, 0'u8, 0'u8, 0'u8, 0'u8, 152'u8, 150'u8, 128'u8]) # 10MB in big endian
-    
+    await clientStream.write(@[0'u8, 0'u8, 0'u8, 0'u8, 0'u8, 152'u8, 150'u8, 128'u8])
+      # 10MB in big endian
+
     # Step 2: Send upload data in chunks
     echo "CLIENT: Starting upload of ", uploadSize, " bytes"
     var remainingToSend = uploadSize
@@ -93,12 +94,12 @@ suite "perf protocol like test - half-close hang":
       await clientStream.write(dummyData)
       remainingToSend -= toSend
       echo "CLIENT: Sent ", toSend, " bytes, remaining: ", remainingToSend
-    
+
     # Step 3: Close write side (this is where the problem happens)
     echo "CLIENT: Upload complete, closing write side"
     await clientStream.closeWrite()
     echo "CLIENT: Write side closed"
-    
+
     # Step 4: Start reading download data
     echo "CLIENT: Starting to read download data"
     var totalDownloaded = 0
@@ -106,8 +107,8 @@ suite "perf protocol like test - half-close hang":
       let chunk = await clientStream.read()
       totalDownloaded += chunk.len
       echo "CLIENT: Downloaded ", chunk.len, " bytes, total: ", totalDownloaded
-    
+
     echo "CLIENT: Download complete"
     await clientStream.close()
-    
+
     await simulation.cancelAndWait()

--- a/tests/quic/testPerf.nim
+++ b/tests/quic/testPerf.nim
@@ -34,73 +34,51 @@ suite "perf protocol like test":
 
     proc serverHandler() {.async.} =
       let serverStream = await server.incomingStream()
-      echo "SERVER: Got incoming stream"
 
       # Step 1: Read download size (8 bytes) 
-      echo "SERVER: Reading download size (8 bytes)"
       let sizeData = await serverStream.read()
-      echo "SERVER: Read download size: ", sizeData.len, " bytes"
       # In real perf this would be parsed as uint64, but we skip that
 
       # Step 2: Read upload data until EOF
-      echo "SERVER: Starting to read upload data"
       var totalBytesRead = 0
       while true:
-        echo "SERVER: Waiting for next chunk..."
         let chunk = await serverStream.read()
-        echo "SERVER: Read chunk: ", chunk.len, " bytes"
-
         if chunk.len == 0:
-          echo "SERVER: Got EOF, total read: ", totalBytesRead
           break
-
         totalBytesRead += chunk.len
-        echo "SERVER: Total bytes read so far: ", totalBytesRead
 
-      echo "SERVER: Starting to send download data"
       # Step 3: Send download data back
       var remainingToSend = downloadSize
       while remainingToSend > 0:
         let toSend = min(remainingToSend, chunkSize)
         await serverStream.write(newSeq[byte](toSend))
         remainingToSend -= toSend
-        echo "SERVER: Sent ", toSend, " bytes, remaining: ", remainingToSend
 
       await serverStream.close()
-      echo "SERVER: Done"
 
     # Start server handler
     asyncSpawn serverHandler()
 
     # Step 1: Send download size (8 bytes) - activate stream first
-    echo "CLIENT: Sending download size"
     await clientStream.write(@[0'u8, 0'u8, 0'u8, 0'u8, 0'u8, 152'u8, 150'u8, 128'u8])
       # 10MB in big endian
 
     # Step 2: Send upload data in chunks
-    echo "CLIENT: Starting upload of ", uploadSize, " bytes"
     var remainingToSend = uploadSize
     while remainingToSend > 0:
       let toSend = min(remainingToSend, chunkSize)
       let dummyData = newSeq[byte](toSend)
       await clientStream.write(dummyData)
       remainingToSend -= toSend
-      echo "CLIENT: Sent ", toSend, " bytes, remaining: ", remainingToSend
 
     # Step 3: Close write side (this is where the problem happens)
-    echo "CLIENT: Upload complete, closing write side"
     await clientStream.closeWrite()
-    echo "CLIENT: Write side closed"
 
     # Step 4: Start reading download data
-    echo "CLIENT: Starting to read download data"
     var totalDownloaded = 0
     while totalDownloaded < downloadSize:
       let chunk = await clientStream.read()
       totalDownloaded += chunk.len
-      echo "CLIENT: Downloaded ", chunk.len, " bytes, total: ", totalDownloaded
 
-    echo "CLIENT: Download complete"
     await clientStream.close()
-
     await simulation.cancelAndWait()

--- a/tests/quic/testPerf.nim
+++ b/tests/quic/testPerf.nim
@@ -57,18 +57,12 @@ suite "perf protocol like test - half-close hang":
         totalBytesRead += chunk.len
         echo "SERVER: Total bytes read so far: ", totalBytesRead
 
-        if totalBytesRead >= uploadSize:
-          echo "SERVER: Read all expected upload data"
-          break # Exit the reading loop once we have all expected data
-
       echo "SERVER: Starting to send download data"
       # Step 3: Send download data back
       var remainingToSend = downloadSize
       while remainingToSend > 0:
         let toSend = min(remainingToSend, chunkSize)
-        let dummyData = newSeq[byte](toSend)
-        echo "about to send"
-        await serverStream.write(dummyData)
+        await serverStream.write(newSeq[byte](toSend))
         remainingToSend -= toSend
         echo "SERVER: Sent ", toSend, " bytes, remaining: ", remainingToSend
 
@@ -77,8 +71,6 @@ suite "perf protocol like test - half-close hang":
 
     # Start server handler
     asyncSpawn serverHandler()
-
-    await clientStream.write(@[])
 
     # Step 1: Send download size (8 bytes) - activate stream first
     echo "CLIENT: Sending download size"

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -16,5 +16,6 @@ import ./quic/testListener
 import ./quic/testApi
 import ./quic/testExample
 import ./quic/testFramesorter
+import ./quic/testPerf
 
 {.warning[UnusedImport]: off.}


### PR DESCRIPTION
`read()` in open state could block when `let data = await state.incoming.get()` getting incoming data but no data is received because eof is transmitted bit later thus missing initial condition checks in `read()` .