### PR TITLE
chore: add parseDatagramDestination

### DIFF
--- a/quic/connection.nim
+++ b/quic/connection.nim
@@ -112,10 +112,11 @@ proc disconnect(connection: Connection) {.async.} =
 proc newIncomingConnection*(
     tlsBackend: TLSBackend,
     udp: DatagramTransport,
+    msg: seq[byte],
     remote: TransportAddress,
     rng: ref HmacDrbgContext,
 ): Connection =
-  let datagram = Datagram(data: udp.getMessage())
+  let datagram = Datagram(data: msg)
   let quic =
     newQuicServerConnection(tlsBackend, udp.localAddress, remote, datagram, rng)
   let closed = newAsyncEvent()

--- a/quic/listener.nim
+++ b/quic/listener.nim
@@ -47,7 +47,7 @@ proc getOrCreateConnection*(
     rng: ref HmacDrbgContext,
 ): Opt[Connection] =
   var connection: Connection
-  let destination = parseDatagram(msg).destination
+  let destination = parseDatagramDestination(msg)
   if not listener.hasConnection(destination):
     if not shouldAccept(msg):
       return Opt.none(Connection)

--- a/quic/listener.nim
+++ b/quic/listener.nim
@@ -62,7 +62,8 @@ proc newListener*(
 ): Listener =
   let listener = Listener(incoming: newAsyncQueue[Connection]())
   proc onReceive(udp: DatagramTransport, remote: TransportAddress) {.async.} =
-    let msg = udp.getMessage() # call getMessage() only once to avoid unnecessary allocation
+    let msg = udp.getMessage()
+      # call getMessage() only once to avoid unnecessary allocation
     let connection = listener.getOrCreateConnection(udp, msg, remote, rng)
     if connection.isSome():
       connection.get().receive(Datagram(data: msg))

--- a/quic/listener.nim
+++ b/quic/listener.nim
@@ -42,16 +42,16 @@ proc addConnection(listener: Listener, connection: Connection, firstId: Connecti
 proc getOrCreateConnection*(
     listener: Listener,
     udp: DatagramTransport,
+    msg: seq[byte],
     remote: TransportAddress,
     rng: ref HmacDrbgContext,
 ): Opt[Connection] =
   var connection: Connection
-  let msg = udp.getMessage()
   let destination = parseDatagram(msg).destination
   if not listener.hasConnection(destination):
     if not shouldAccept(msg):
       return Opt.none(Connection)
-    connection = newIncomingConnection(listener.tlsBackend, udp, remote, rng)
+    connection = newIncomingConnection(listener.tlsBackend, udp, msg, remote, rng)
     listener.addConnection(connection, destination)
   else:
     connection = listener.getConnection(destination)
@@ -62,9 +62,10 @@ proc newListener*(
 ): Listener =
   let listener = Listener(incoming: newAsyncQueue[Connection]())
   proc onReceive(udp: DatagramTransport, remote: TransportAddress) {.async.} =
-    let connection = listener.getOrCreateConnection(udp, remote, rng)
+    let msg = udp.getMessage() # call getMessage() only once to avoid unnecessary allocation
+    let connection = listener.getOrCreateConnection(udp, msg, remote, rng)
     if connection.isSome():
-      connection.get().receive(Datagram(data: udp.getMessage()))
+      connection.get().receive(Datagram(data: msg))
 
   listener.tlsBackend = tlsBackend
   listener.udp = newDatagramTransport(onReceive, local = address)

--- a/quic/transport/ngtcp2/native.nim
+++ b/quic/transport/ngtcp2/native.nim
@@ -7,7 +7,7 @@ import ./native/parsedatagram
 import ./native/picotls
 import ./native/certificateverifier
 
-export parseDatagram
+export parseDatagramInfo
 export parseDatagramDestination
 export Ngtcp2Connection
 export newNgtcp2Client

--- a/quic/transport/ngtcp2/native.nim
+++ b/quic/transport/ngtcp2/native.nim
@@ -9,6 +9,7 @@ import ./native/certificateverifier
 
 export parseDatagramInfo
 export parseDatagramDestination
+export shouldAccept
 export Ngtcp2Connection
 export newNgtcp2Client
 export newNgtcp2Server

--- a/quic/transport/ngtcp2/native.nim
+++ b/quic/transport/ngtcp2/native.nim
@@ -8,6 +8,7 @@ import ./native/picotls
 import ./native/certificateverifier
 
 export parseDatagram
+export parseDatagramDestination
 export Ngtcp2Connection
 export newNgtcp2Client
 export newNgtcp2Server

--- a/quic/transport/ngtcp2/native/parsedatagram.nim
+++ b/quic/transport/ngtcp2/native/parsedatagram.nim
@@ -20,6 +20,13 @@ proc parseDatagram*(datagram: openArray[byte]): PacketInfo =
     version: version.version.uint32,
   )
 
+proc parseDatagramDestination*(datagram: openArray[byte]): ConnectionId =
+  var version: ngtcp2_version_cid
+  checkResult ngtcp2_pkt_decode_version_cid(
+    addr version, unsafeAddr datagram[0], datagram.len.uint, DefaultConnectionIdLength
+  )
+  return toConnectionId(version.dcid, version.dcidlen)
+
 proc shouldAccept*(datagram: openArray[byte]): bool =
   var hd: ngtcp2_pkt_hd
   let ret = ngtcp2_accept(hd.unsafeAddr, datagram[0].unsafeAddr, datagram.len.uint)

--- a/quic/transport/ngtcp2/native/parsedatagram.nim
+++ b/quic/transport/ngtcp2/native/parsedatagram.nim
@@ -9,7 +9,7 @@ proc toConnectionId(p: ptr byte, length: uint): ConnectionId =
   copyMem(bytes.toPtr, p, length)
   ConnectionId(bytes)
 
-proc parseDatagram*(datagram: openArray[byte]): PacketInfo =
+proc parseDatagramInfo*(datagram: openArray[byte]): PacketInfo =
   var version: ngtcp2_version_cid
   checkResult ngtcp2_pkt_decode_version_cid(
     addr version, unsafeAddr datagram[0], datagram.len.uint, DefaultConnectionIdLength

--- a/quic/transport/ngtcp2/native/server.nim
+++ b/quic/transport/ngtcp2/native/server.nim
@@ -111,7 +111,7 @@ proc newNgtcp2Server*(
     datagram: openArray[byte],
     rng: ref HmacDrbgContext,
 ): Ngtcp2Connection =
-  let info = parseDatagram(datagram)
+  let info = parseDatagramInfo(datagram)
   newNgtcp2Server(
     tlsContext, local, remote, info.source.toCid, info.destination.toCid, rng
   )

--- a/quic/transport/ngtcp2/native/server.nim
+++ b/quic/transport/ngtcp2/native/server.nim
@@ -105,15 +105,13 @@ proc newNgtcp2Server*(
   nConn.tlsContext = tlsContext
   nConn
 
-proc extractIds(datagram: openArray[byte]): tuple[source, dest: ngtcp2_cid] =
-  let info = parseDatagram(datagram)
-  (source: info.source.toCid, dest: info.destination.toCid)
-
 proc newNgtcp2Server*(
     tlsContext: PicoTLSContext,
     local, remote: TransportAddress,
     datagram: openArray[byte],
     rng: ref HmacDrbgContext,
 ): Ngtcp2Connection =
-  let (source, destination) = extractIds(datagram)
-  newNgtcp2Server(tlsContext, local, remote, source, destination, rng)
+  let info = parseDatagram(datagram)
+  newNgtcp2Server(
+    tlsContext, local, remote, info.source.toCid, info.destination.toCid, rng
+  )

--- a/quic/transport/parsedatagram.nim
+++ b/quic/transport/parsedatagram.nim
@@ -1,4 +1,4 @@
 import ./ngtcp2/native/parsedatagram
 
-export parseDatagram
+export parseDatagramInfo
 export parseDatagramDestination

--- a/quic/transport/parsedatagram.nim
+++ b/quic/transport/parsedatagram.nim
@@ -1,3 +1,4 @@
 import ./ngtcp2/native/parsedatagram
 
 export parseDatagram
+export parseDatagramDestination

--- a/quic/transport/parsedatagram.nim
+++ b/quic/transport/parsedatagram.nim
@@ -2,3 +2,4 @@ import ./ngtcp2/native/parsedatagram
 
 export parseDatagramInfo
 export parseDatagramDestination
+export shouldAccept

--- a/tests/quic/testParseDatagram.nim
+++ b/tests/quic/testParseDatagram.nim
@@ -19,16 +19,16 @@ suite "parse ngtcp2 packet info":
     datagram.write(packet)
 
   test "extracts destination id":
-    let info = parseDatagram(datagram)
+    let info = parseDatagramInfo(datagram)
     check info.destination == packet.destination
 
     let destination = parseDatagramDestination(datagram)
     check info.destination == destination
 
   test "extracts source id":
-    let info = parseDatagram(datagram)
+    let info = parseDatagramInfo(datagram)
     check info.source == packet.source
 
   test "extracts version":
-    let info = parseDatagram(datagram)
+    let info = parseDatagramInfo(datagram)
     check info.version == packet.initial.version

--- a/tests/quic/testParseDatagram.nim
+++ b/tests/quic/testParseDatagram.nim
@@ -22,6 +22,9 @@ suite "parse ngtcp2 packet info":
     let info = parseDatagram(datagram)
     check info.destination == packet.destination
 
+    let destination = parseDatagramDestination(datagram)
+    check info.destination == destination
+
   test "extracts source id":
     let info = parseDatagram(datagram)
     check info.source == packet.source

--- a/tests/quic/testParseDatagram.nim
+++ b/tests/quic/testParseDatagram.nim
@@ -1,18 +1,16 @@
 import std/unittest
 
 import ngtcp2
-import bearssl/rand
 import quic/helpers/rand
 import quic/transport/[packets, parsedatagram, version]
 
 suite "parse ngtcp2 packet info":
   var packet: Packet
   var datagram: array[4096, byte]
-  var rng: ref HmacDrbgContext
 
   setup:
+    let rng = newRng()
     packet = initialPacket(CurrentQuicVersion)
-    rng = newRng()
     packet.source = randomConnectionId(rng)
     packet.destination = randomConnectionId(rng)
     datagram = typeof(datagram).default


### PR DESCRIPTION
- add `parseDatagramDestination`  specialized proc that only parses destination component in order to reduce total memory usage.
- rename `parseDatagram` to `parseDatagramInfo` to be more descriptive

effort for: https://github.com/vacp2p/nim-libp2p/issues/1621