### PR TITLE
chore: make datagram ref object

### DIFF
--- a/quic/connection.nim
+++ b/quic/connection.nim
@@ -201,7 +201,7 @@ proc waitForHandshake*(
     errFut.cancelSoon()
     timeoutFut.cancelSoon()
 
-proc receive*(connection: Connection, datagram: Datagram) =
+proc receive*(connection: Connection, datagram: sink Datagram) =
   connection.quic.receive(datagram)
 
 proc remoteAddress*(

--- a/quic/transport/ngtcp2/connection/closedstate.nim
+++ b/quic/transport/ngtcp2/connection/closedstate.nim
@@ -21,7 +21,7 @@ method ids(state: ClosedConnection): seq[ConnectionId] =
 method send(state: ClosedConnection) =
   raise newException(ClosedConnectionError, "connection is closed")
 
-method receive(state: ClosedConnection, datagram: Datagram) =
+method receive(state: ClosedConnection, datagram: sink Datagram) =
   raise newException(ClosedConnectionError, "connection is closed")
 
 method openStream(

--- a/quic/transport/ngtcp2/connection/disconnectingstate.nim
+++ b/quic/transport/ngtcp2/connection/disconnectingstate.nim
@@ -45,7 +45,7 @@ method leave(state: DisconnectingConnection) =
 method send(state: DisconnectingConnection) =
   raise newException(ClosedConnectionError, "connection is disconnecting")
 
-method receive(state: DisconnectingConnection, datagram: Datagram) =
+method receive(state: DisconnectingConnection, datagram: sink Datagram) =
   discard
 
 method openStream(

--- a/quic/transport/ngtcp2/connection/drainingstate.nim
+++ b/quic/transport/ngtcp2/connection/drainingstate.nim
@@ -56,7 +56,7 @@ method ids(state: DrainingConnection): seq[ConnectionId] {.raises: [].} =
 method send(state: DrainingConnection) =
   raise newException(ClosedConnectionError, "connection is closing")
 
-method receive(state: DrainingConnection, datagram: Datagram) =
+method receive(state: DrainingConnection, datagram: sink Datagram) =
   discard
 
 method openStream(

--- a/quic/transport/ngtcp2/connection/openstate.nim
+++ b/quic/transport/ngtcp2/connection/openstate.nim
@@ -104,7 +104,7 @@ method ids(state: OpenConnection): seq[ConnectionId] {.raises: [].} =
 method send(state: OpenConnection) =
   state.ngtcp2Connection.send()
 
-method receive(state: OpenConnection, datagram: Datagram) =
+method receive(state: OpenConnection, datagram: sink Datagram) =
   var errCode = 0
   var errMsg = ""
   try:

--- a/quic/transport/ngtcp2/native/connection.nim
+++ b/quic/transport/ngtcp2/native/connection.nim
@@ -183,7 +183,7 @@ proc send*(
       messageLen = messageLen - written.uint
       done = messageLen == 0
 
-proc tryReceive(connection: Ngtcp2Connection, datagram: openArray[byte], ecn: ECN) =
+proc tryReceive(connection: Ngtcp2Connection, datagram: sink seq[byte], ecn: ECN) =
   let conn = connection.conn.valueOr:
     raise newException(Ngtcp2ConnectionClosed, "connection no longer exists")
 
@@ -199,14 +199,14 @@ proc tryReceive(connection: Ngtcp2Connection, datagram: openArray[byte], ecn: EC
     now(),
   )
 
-proc receive*(
-    connection: Ngtcp2Connection, datagram: openArray[byte], ecn = ecnNonCapable
+proc receive(
+    connection: Ngtcp2Connection, datagram: sink seq[byte], ecn = ecnNonCapable
 ) =
   connection.tryReceive(datagram, ecn)
   connection.send()
   connection.flowing.fire()
 
-proc receive*(connection: Ngtcp2Connection, datagram: Datagram) =
+proc receive*(connection: Ngtcp2Connection, datagram: sink Datagram) =
   connection.receive(datagram.data, datagram.ecn)
 
 proc handleTimeout(connection: Ngtcp2Connection) =

--- a/quic/transport/quicconnection.nim
+++ b/quic/transport/quicconnection.nim
@@ -40,7 +40,7 @@ method ids*(state: ConnectionState): seq[ConnectionId] {.raises: [].} =
 method send*(state: ConnectionState) =
   doAssert false # override this method
 
-method receive*(state: ConnectionState, datagram: Datagram) =
+method receive*(state: ConnectionState, datagram: sink Datagram) =
   doAssert false # override this method
 
 method openStream*(state: ConnectionState, unidirectional: bool): Future[Stream] =
@@ -82,7 +82,7 @@ proc ids*(connection: QuicConnection): seq[ConnectionId] =
 proc send*(connection: QuicConnection) =
   connection.state.send()
 
-proc receive*(connection: QuicConnection, datagram: Datagram) =
+proc receive*(connection: QuicConnection, datagram: sink Datagram) =
   connection.state.receive(datagram)
 
 proc openStream*(connection: QuicConnection, unidirectional = false): Future[Stream] =

--- a/quic/udp/datagram.nim
+++ b/quic/udp/datagram.nim
@@ -1,6 +1,6 @@
 import ./congestion
 
-type Datagram* = object
+type Datagram* = ref object
   data*: seq[byte]
   ecn*: ECN
 


### PR DESCRIPTION
- making `Datagram` as ref object improves performance slightly
- `sink` does not have any effect on performance, but it makes sense to be used so that developers can understand where ownership of `Datagram` is