### PR TITLE
chore: receive should not raise error

### DIFF
--- a/quic/transport/ngtcp2/connection/closedstate.nim
+++ b/quic/transport/ngtcp2/connection/closedstate.nim
@@ -22,7 +22,7 @@ method send(state: ClosedConnection) =
   raise newException(ClosedConnectionError, "connection is closed")
 
 method receive(state: ClosedConnection, datagram: sink Datagram) =
-  discard
+  warn "Receive ClosedConnection state"
 
 method openStream(
     state: ClosedConnection, unidirectional: bool

--- a/quic/transport/ngtcp2/connection/closedstate.nim
+++ b/quic/transport/ngtcp2/connection/closedstate.nim
@@ -22,7 +22,7 @@ method send(state: ClosedConnection) =
   raise newException(ClosedConnectionError, "connection is closed")
 
 method receive(state: ClosedConnection, datagram: sink Datagram) =
-  raise newException(ClosedConnectionError, "connection is closed")
+  discard
 
 method openStream(
     state: ClosedConnection, unidirectional: bool
@@ -33,6 +33,4 @@ method close(state: ClosedConnection) {.async.} =
   discard
 
 method drop(state: ClosedConnection) {.async.} =
-  trace "Dropping ClosedConnection state"
-  discard
-  trace "Dropped ClosedConnection state"
+  trace "Drop ClosedConnection state"

--- a/quic/transport/ngtcp2/connection/disconnectingstate.nim
+++ b/quic/transport/ngtcp2/connection/disconnectingstate.nim
@@ -60,11 +60,8 @@ method close(state: DisconnectingConnection) {.async.} =
   connection.switch(newClosedConnection(state.derCertificates))
 
 method drop(state: DisconnectingConnection) {.async.} =
-  trace "Dropping DisconnectingConnection state"
-  trace "Awaiting quic disconnecton"
+  trace "Drop DisconnectingConnection state"
   await state.disconnect
-  trace "Quic disconnecton finished"
   let connection = state.connection.valueOr:
     return
   connection.switch(newClosedConnection(state.derCertificates))
-  trace "dropped DisconnectingConnection state"


### PR DESCRIPTION
`receive` should not raise error in `ClosedConnection`. it should do nothing, or just log the event.

- `ClosedConnection` is transitioned from `DisconnectingConnection` which currently doesn't do anything on `receive`. so it doesn't make sense to start throwing in next state.
- if `ClosedConnection` do `receive` it's likely race condition in process of ending connection so we should not care 


this pr also removed some spamming logs. 