### PR TITLE
fix: close conn after timeout

### DIFF
--- a/quic/transport/ngtcp2/connstate/openstate.nim
+++ b/quic/transport/ngtcp2/connstate/openstate.nim
@@ -63,11 +63,9 @@ method enter(
     connection.handshake.fire()
 
   state.ngtcp2Connection.onTimeout = proc() {.gcsafe, raises: [].} =
-    try:
-      connection.timeout.fire()
-      state.streams.expireAll()
-    except Ngtcp2ConnectionClosed:
-      trace "connection closed"
+    connection.timeout.fire()
+    state.streams.expireAll()
+    discard state.close()
 
   trace "Entered OpenConnection state"
 
@@ -84,15 +82,6 @@ method ids(state: OpenConnection): seq[ConnectionId] {.raises: [].} =
 
 method send(state: OpenConnection) {.raises: [QuicError].} =
   state.ngtcp2Connection.send()
-
-proc asyncClose(state: ConnectionState) =
-  proc close() {.async: (raises: []).} =
-    try:
-      await state.close()
-    except CatchableError as e:
-      trace "Failed to close state", msg = e.msg
-
-  asyncSpawn close()
 
 method receive(state: OpenConnection, datagram: sink Datagram) {.raises: [QuicError].} =
   var errCode = 0
@@ -111,7 +100,7 @@ method receive(state: OpenConnection, datagram: sink Datagram) {.raises: [QuicEr
       let duration = state.ngtcp2Connection.closingDuration()
       let draining = newDrainingConnection(ids, duration, state.derCertificates)
       quicConnection.switch(draining)
-      asyncClose(draining)
+      discard draining.close()
 
       if not state.handshakeCompleted:
         # When a server for any reason decides that the certificate is
@@ -121,7 +110,7 @@ method receive(state: OpenConnection, datagram: sink Datagram) {.raises: [QuicEr
         quicConnection.error.emit("ERR_HANDSHAKE_FAILED")
     elif errCode != 0 and errCode != NGTCP2_ERR_DROP_CONN:
       quicConnection.error.emit(errMsg)
-      asyncClose(state)
+      discard state.close()
 
 method openStream(
     state: OpenConnection, unidirectional: bool

--- a/tests/quic/testQuicConnection.nim
+++ b/tests/quic/testQuicConnection.nim
@@ -58,18 +58,10 @@ suite "quic connection":
       )
 
   asyncTest "performs handshake":
-    let (client, server) = await performHandshake()
-    defer:
-      await client.drop()
-    defer:
-      await server.drop()
-
-    check client.handshake.isSet()
-    check server.handshake.isSet()
-
-  asyncTest "performs handshake multiple times":
-    for i in 1 .. 100:
+    for i in 1 .. 10:
       let (client, server) = await performHandshake()
+      check client.handshake.isSet()
+      check server.handshake.isSet()
       await client.drop()
       await server.drop()
 
@@ -121,9 +113,6 @@ suite "quic connection":
 
     expect ConnectionError:
       connection.send()
-
-    expect ConnectionError:
-      connection.receive(Datagram(data: @[]))
 
     expect ConnectionError:
       discard await connection.openStream()


### PR DESCRIPTION
after timeout connection is closed which will terminate all open streams and all futures waiting for streams to open.

fix: https://github.com/vacp2p/nim-quic/issues/131